### PR TITLE
Update debian control files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,19 +9,25 @@ Vcs-Git: https://github.com/enova/pg_fact_loader.git
 
 Package: postgresql-9.5-pg-fact-loader
 Architecture: any
-Depends: postgresql-9.5, postgresql-9.5-pglogical, ${shlibs:Depends}, ${misc:Depends}
-Description: Build fact tables asynchronously with Postgres using queue tables 
- Build fact tables asynchronously with Postgres using queue tables 
+Depends: postgresql-9.5, ${shlibs:Depends}, ${misc:Depends}
+Description: Build fact tables asynchronously with Postgres
+ Use queue tables to build fact tables asynchronously for PostgreSQL 9.5.
 
 Package: postgresql-9.6-pg-fact-loader
 Architecture: any
-Depends: postgresql-9.6, postgresql-9.6-pglogical, ${shlibs:Depends}, ${misc:Depends}
-Description: Have time-based replication delay for pglogical
- A pglogical extension to obtain time-based replication delay for PostgreSQL 9.6.
+Depends: postgresql-9.6, ${shlibs:Depends}, ${misc:Depends}
+Description: Build fact tables asynchronously with Postgres
+ Use queue tables to build fact tables asynchronously for PostgreSQL 9.6.
 
 Package: postgresql-10-pg-fact-loader
 Architecture: any
-Depends: postgresql-10, postgresql-10-pglogical, ${shlibs:Depends}, ${misc:Depends}
-Description: Have time-based replication delay for pglogical
- A pglogical extension to obtain time-based replication delay for PostgreSQL 10.
+Depends: postgresql-10, ${shlibs:Depends}, ${misc:Depends}
+Description: Build fact tables asynchronously with Postgres
+ Use queue tables to build fact tables asynchronously for PostgreSQL 10.
+
+Package: postgresql-11-pg-fact-loader
+Architecture: any
+Depends: postgresql-11, ${shlibs:Depends}, ${misc:Depends}
+Description: Build fact tables asynchronously with Postgres
+ Use queue tables to build fact tables asynchronously for PostgreSQL 11.
 

--- a/debian/control.in
+++ b/debian/control.in
@@ -9,6 +9,6 @@ Vcs-Git: https://github.com/enova/pg_fact_loader.git
 
 Package: postgresql-PGVERSION-pg-fact-loader
 Architecture: any
-Depends: postgresql-PGVERSION, postgresql-PGVERSION-pglogical, ${shlibs:Depends}, ${misc:Depends}
+Depends: postgresql-PGVERSION, ${shlibs:Depends}, ${misc:Depends}
 Description: Build fact tables asynchronously with Postgres
  Use queue tables to build fact tables asynchronously for PostgreSQL PGVERSION.

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
-Depends: @, postgresql-server-dev-all
+Depends: @, postgresql-server-dev-all, postgresql-9.5-pglogical, postgresql-9.6-pglogical, postgresql-10-pglogical, postgresql-11-pglogical, postgresql-9.5-pglogical, postgresql-9.6-pglogical, postgresql-10-pglogical, postgresql-11-pglogical-ticker
 Tests: installcheck
 Restrictions: allow-stderr

--- a/debian/tests/control.in
+++ b/debian/tests/control.in
@@ -1,0 +1,3 @@
+Depends: @, postgresql-server-dev-all, postgresql-PGVERSION-pglogical, postgresql-PGVERSION-pglogical-ticker
+Tests: installcheck
+Restrictions: allow-stderr


### PR DESCRIPTION
This extension can be used with or without pglogical and pglogical_ticker, but many of the tests do depend on pglogical.  So we have deps on pglogical only in the `debian/tests/control` file, but not in `debian/control`.