### PR TITLE
Test-Depend on postgresql-contrib-PGVERSION.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pg-fact-loader (1.5.1-2) UNRELEASED; urgency=medium
+
+  * Test-Depend on postgresql-contrib-PGVERSION.
+
+ -- Christoph Berg <christoph.berg@credativ.de>  Wed, 28 Nov 2018 15:06:02 +0100
+
 pg-fact-loader (1.5.1-1) unstable; urgency=medium
 
   * Fixes for old version tests 

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
-Depends: @, postgresql-server-dev-all, postgresql-9.5-pglogical, postgresql-9.6-pglogical, postgresql-10-pglogical, postgresql-11-pglogical, postgresql-9.5-pglogical, postgresql-9.6-pglogical, postgresql-10-pglogical, postgresql-11-pglogical-ticker
+Depends: @, postgresql-server-dev-all, postgresql-contrib-9.5, postgresql-contrib-9.6, postgresql-contrib-10, postgresql-contrib-11, postgresql-9.5-pglogical, postgresql-9.6-pglogical, postgresql-10-pglogical, postgresql-11-pglogical, postgresql-9.5-pglogical-ticker, postgresql-9.6-pglogical-ticker, postgresql-10-pglogical-ticker, postgresql-11-pglogical-ticker
 Tests: installcheck
 Restrictions: allow-stderr

--- a/debian/tests/control.in
+++ b/debian/tests/control.in
@@ -1,3 +1,3 @@
-Depends: @, postgresql-server-dev-all, postgresql-PGVERSION-pglogical, postgresql-PGVERSION-pglogical-ticker
+Depends: @, postgresql-server-dev-all, postgresql-contrib-PGVERSION, postgresql-PGVERSION-pglogical, postgresql-PGVERSION-pglogical-ticker
 Tests: installcheck
 Restrictions: allow-stderr


### PR DESCRIPTION
This is needed because the regression tests need the "hstore" extension.