### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 pg-fact-loader (1.6.0-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 05 Feb 2022 09:00:36 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,15 +1,21 @@
+pg-fact-loader (1.6.0-2) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 05 Feb 2022 09:00:36 -0000
+
 pg-fact-loader (1.6.0-1) unstable; urgency=medium
 
-  * Change regproc to text to allow pgupgrade 
+  * Change regproc to text to allow pgupgrade
   * Ensure pg12 readiness
 
  -- Jeremy Finzel <jfinzel@enova.com>  Mon, 31 Aug 2020 10:23:10 -0500
 
 pg-fact-loader (1.5.2-1) unstable; urgency=medium
 
-  * Fix time zone bug and behavior of SIGTERM 
+  * Fix time zone bug and behavior of SIGTERM
 
- -- Jeremy Finzel <jfinzel@enova.com>  Thu, 29 Nov 2018 10:36:36 -0600 
+ -- Jeremy Finzel <jfinzel@enova.com>  Thu, 29 Nov 2018 10:36:36 -0600
 
 pg-fact-loader (1.5.1-2) UNRELEASED; urgency=medium
 
@@ -19,12 +25,12 @@ pg-fact-loader (1.5.1-2) UNRELEASED; urgency=medium
 
 pg-fact-loader (1.5.1-1) unstable; urgency=medium
 
-  * Fixes for old version tests 
+  * Fixes for old version tests
 
- -- Jeremy Finzel <jfinzel@enova.com>  Tue, 27 Nov 2018 09:23:57 -0600 
- 
+ -- Jeremy Finzel <jfinzel@enova.com>  Tue, 27 Nov 2018 09:23:57 -0600
+
 pg-fact-loader (1.5.0-1) unstable; urgency=medium
 
-  * Initial public version of pg_fact_loader 
+  * Initial public version of pg_fact_loader
 
- -- Jeremy Finzel <jfinzel@enova.com>  Fri, 09 Nov 2018 11:54:11 -0600 
+ -- Jeremy Finzel <jfinzel@enova.com>  Fri, 09 Nov 2018 11:54:11 -0600

--- a/debian/control
+++ b/debian/control
@@ -30,4 +30,3 @@ Architecture: any
 Depends: postgresql-11, ${shlibs:Depends}, ${misc:Depends}
 Description: Build fact tables asynchronously with Postgres
  Use queue tables to build fact tables asynchronously for PostgreSQL 11.
-

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/enova/pg_fact_loader/issues
+Bug-Submit: https://github.com/enova/pg_fact_loader/issues/new
+Repository: https://github.com/enova/pg_fact_loader.git
+Repository-Browse: https://github.com/enova/pg_fact_loader


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/pg-fact-loader/12b0d38e-0fe2-46b8-8aae-c5bf38dfb3c5.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/12b0d38e-0fe2-46b8-8aae-c5bf38dfb3c5/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/12b0d38e-0fe2-46b8-8aae-c5bf38dfb3c5/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/12b0d38e-0fe2-46b8-8aae-c5bf38dfb3c5/diffoscope)).
