### PR TITLE
Index process_queue by bigint where applicable

### DIFF
--- a/functions/load.sql
+++ b/functions/load.sql
@@ -29,6 +29,13 @@ This just creates a temp table with all changes to be processed
 RAISE DEBUG 'Populating Queue for fact_table_id %: %', p_fact_table_id, v_process_queue_sql;
 EXECUTE COALESCE(v_process_queue_sql, $$SELECT 'No queue data' AS result$$);
 
+-- Numeric index for process_queue - for special use cases
+IF (SELECT COUNT(1) = SUM(case when key_value ~ '^[0-9\.]+$' then 1 else 0 end) FROM process_queue) THEN
+    RAISE LOG 'Indexing process_queue';
+    CREATE INDEX ON process_queue ((key_value::bigint));
+    ANALYZE process_queue;
+END IF;
+
 /****
 For DEBUG purposes only to view the actual process_queue.  Requires setting log_min_messages to DEBUG.
  */


### PR DESCRIPTION
```
$ ./test_all_versions.sh

*******************FROM VERSION 1.7******************

rm -f pg_fact_loader.so pg_fact_loader.o
rm -rf results/ regression.diffs regression.out tmp_check/ tmp_check_iso/ log/ output_iso/
rm -f '/usr/share/postgresql/10/extension'/pg_fact_loader.control
rm -f '/usr/share/postgresql/10/extension'/pg_fact_loader--1.4.sql '/usr/share/postgresql/10/extension'/pg_fact_loader--1.4--1.5.sql '/usr/share/postgresql/10/extension'/pg_fact_loader--1.5.sql '/usr/share/postgresql/10/extension'/pg_fact_loader--1.5--1.6.sql '/usr/share/postgresql/10/extension'/pg_fact_loader--1.6.sql '/usr/share/postgresql/10/extension'/pg_fact_loader--1.6--1.7.sql '/usr/share/postgresql/10/extension'/pg_fact_loader--1.7.sql
rm -f '/usr/lib/postgresql/10/lib'/pg_fact_loader.so
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -g -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fPIC -pie -fno-omit-frame-pointer -fPIC -I. -I./ -I/usr/include/postgresql/10/server -I/usr/include/postgresql/internal -I/usr/include/x86_64-linux-gnu -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include/mit-krb5  -c -o pg_fact_loader.o pg_fact_loader.c
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -g -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fPIC -pie -fno-omit-frame-pointer -fPIC -L/usr/lib/x86_64-linux-gnu -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now  -L/usr/lib/x86_64-linux-gnu/mit-krb5 -Wl,--as-needed  -shared -o pg_fact_loader.so pg_fact_loader.o
/bin/mkdir -p '/usr/share/postgresql/10/extension'
/bin/mkdir -p '/usr/share/postgresql/10/extension'
/bin/mkdir -p '/usr/lib/postgresql/10/lib'
/usr/bin/install -c -m 644 .//pg_fact_loader.control '/usr/share/postgresql/10/extension/'
/usr/bin/install -c -m 644 .//pg_fact_loader--1.4.sql .//pg_fact_loader--1.4--1.5.sql .//pg_fact_loader--1.5.sql .//pg_fact_loader--1.5--1.6.sql .//pg_fact_loader--1.6.sql .//pg_fact_loader--1.6--1.7.sql .//pg_fact_loader--1.7.sql  '/usr/share/postgresql/10/extension/'
/usr/bin/install -c -m 755  pg_fact_loader.so '/usr/lib/postgresql/10/lib/'
NOTICE:  drop cascades to extension pglogical_ticker
NOTICE:  drop cascades to table pglogical_ticker.test1 membership in replication set test1
NOTICE:  drop cascades to table pglogical_ticker.ddl_sql membership in replication set ddl_sql
NOTICE:  drop cascades to table pglogical_ticker.default_insert_only membership in replication set default_insert_only
NOTICE:  drop cascades to table pglogical_ticker."default" membership in replication set default
DROP EXTENSION
 pg_terminate_backend
----------------------
 t
(1 row)

/usr/lib/postgresql/10/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/lib/postgresql/10/bin'    --dbname=contrib_regression 01_create_ext 02_schema 03_audit 04_seeds 05_pgl_setup 06_basic_workers 07_launch_worker 08_fact_table_deps 09_purge 10_delete 11_more_data 12_no_proid 13_cutoff_no_dep_on_filter 14_null_key 15_source_change_date 16_1_2_features 17_1_3_features
(using postmaster on Unix socket, port 5432)
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test 01_create_ext            ... ok
test 02_schema                ... ok
test 03_audit                 ... ok
test 04_seeds                 ... ok
test 05_pgl_setup             ... ok
test 06_basic_workers         ... ok
test 07_launch_worker         ... ok
test 08_fact_table_deps       ... ok
test 09_purge                 ... ok
test 10_delete                ... ok
test 11_more_data             ... ok
test 12_no_proid              ... ok
test 13_cutoff_no_dep_on_filter ... ok
test 14_null_key              ... ok
test 15_source_change_date    ... ok
test 16_1_2_features          ... ok
test 17_1_3_features          ... ok

======================
 All 17 tests passed.
======================

```